### PR TITLE
[FEAT:TasksList] Add a filter to only show tasks assigned to the connected user

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -8,7 +8,7 @@ function App() {
 	return (
 		<div className="App bg-pink-700">
 			<AuthenticationHeader />
-			<TasksList />
+			<TasksList userId={userId} />
 		</div>
 	);
 }

--- a/front/src/components/TasksList.tsx
+++ b/front/src/components/TasksList.tsx
@@ -173,18 +173,28 @@ const rolesData = [{ id: 1, title: "Développeur" }];
 
 const statusData = [{ id: 1, title: "En cours" }];
 
-export const TasksList = () => (
+interface IProps {
+	userId: string;
+}
+
+export const TasksList = ({ userId }: IProps) => (
 	<ul className="flex">
-		{tasksData.map(({ title, status_id }) => {
-			const currStatus = statusData.find(({ id }) => id === status_id);
-			return (
-				<li className="flex-1 p-2">
-					<header className="flex justify-between">
-						<strong>{title}</strong>{" "}
-						{currStatus && <span>{currStatus.title}</span>}
-					</header>
-				</li>
-			);
-		})}
+		{tasksData
+			.filter(({ user_id }) => !userId || user_id === Number(userId))
+			.map(({ title, status_id, user_id }) => {
+				const currStatus = statusData.find(
+					({ id }) => id === status_id
+				);
+				return (
+					<li className="flex-1 border border-purple-800 p-2">
+						<header className="flex justify-between">
+							<span>
+								<strong>{title}</strong> (user {user_id})
+							</span>{" "}
+							{currStatus && <span>{currStatus.title}</span>}
+						</header>
+					</li>
+				);
+			})}
 	</ul>
 );


### PR DESCRIPTION
When no user is connected, all tasks are visible. If `userId`exists, all the tasks not assigned to the current user are hidden. 
(Currently there are only two user, with user_id `1` and `2` respectively)

I have added the `user_id` for each task to the rendered `<li>`element to show more obviously that the feature works, but we will certainly remove it in the future.
